### PR TITLE
App add error handling

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -57,5 +57,8 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
+    },
+    "devDependencies": {
+        "jest-extended": "^0.11.5"
     }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,7 +9,7 @@ import AddSprint from './pages/AddSprint';
 import AddProject from './pages/AddProject';
 import AddPost from './pages/AddPost';
 import EditSprint from './pages/EditSprint';
-import { Sprint } from './pages/Sprint';
+import Sprint from './pages/Sprint';
 import './App.css';
 import authService from './services/authService';
 

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import App from './App';
 import authService, { resolveWhoAmi, rejectWhoAmi } from './services/authService';
+import * as MockSprintsService from './services/sprintsService';
 
 jest.mock('./services/authService');
+jest.mock('./services/sprintsService');
 
 describe('landing page', () => {
     test('Waits from whoami and renders an enter button', () => {
@@ -16,5 +18,20 @@ describe('landing page', () => {
         resolveWhoAmi({ user: { username: 'username' } });
         const enterButtonPromise = findByText(/enter the boon/i);
         return expect(enterButtonPromise).resolves.toBeInTheDocument();
+    });
+});
+
+describe('app', () => {
+    test('Displays a list of sprints', async () => {
+        const { getByText, findByText, findAllByText } = render(<App />);
+
+        // Resolve all requests upfront to make the test simpler.
+        resolveWhoAmi({ user: { username: 'username' } });
+        MockSprintsService.resolveGetAll([
+            { _id: 'sprint0Id', number: 0, title: 'sprint0Title', author: { _id: 'user0Id' } },
+        ]);
+
+        await fireEvent.click(await findByText(/enter the boon/i));
+        await expect(findAllByText(/sprint0Title/i)).resolves.not.toBeEmpty();
     });
 });

--- a/client/src/components/sprint/SprintsView.js
+++ b/client/src/components/sprint/SprintsView.js
@@ -28,6 +28,7 @@ const SprintsView = props => {
     const [sprints, setSprints] = useState(null);
 
     const getSprints = async () => {
+        // TODO: store `sprints` in `App.js`, pass by props
         let res = await sprintsService.getAll().catch(props.onError);
         setSprints(res);
         props.initializeSprint(res);

--- a/client/src/components/sprint/details/ModifyButtons.js
+++ b/client/src/components/sprint/details/ModifyButtons.js
@@ -12,12 +12,7 @@ export const SprintModifyButtons = ({ user, sprint, model, onError }) => {
                 <React.Fragment>
                     {sprint.author.id === user._id ? (
                         <React.Fragment>
-                            <ObjectDeleteButton
-                                user={user}
-                                model={model}
-                                object={sprint}
-                                onError={onError.bind('deleteSprint')}
-                            />
+                            <ObjectDeleteButton user={user} model={model} object={sprint} onError={onError} />
                             <ObjectEditButton user={user} model={model} object={sprint} />
                         </React.Fragment>
                     ) : null}

--- a/client/src/components/withShowError.js
+++ b/client/src/components/withShowError.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import NotificationObject from '../logic/NotificationObject';
+
+// Wrapp a component with `notificationProps` prop, inject a `showError` property
+// parsing and queueing an error notifcation.
+const withShowError = wrappedComponent => props => {
+    const {
+        notificationsProps: { addNotification },
+    } = props;
+    const showError = err => addNotification(NotificationObject.make(err.toString()));
+    return wrappedComponent({ ...props, showError });
+};
+
+export default withShowError;

--- a/client/src/pages/AddPost.js
+++ b/client/src/pages/AddPost.js
@@ -9,15 +9,15 @@ import { withPush } from '../utils/routingDecorators';
 import AppLayout from '../layouts/AppLayout';
 import '../styles/main.css';
 import { useParams } from 'react-router-dom';
+import withShowError from '../components/withShowError';
 
-const AddPost = ({ user, sprintId, push, notificationsProps }) => {
+const AddPost = ({ user, sprintId, push, notificationsProps, showError }) => {
     const { id } = useParams();
 
     const [sprint, setSprint] = useState(null);
 
     const getSprint = async () => {
-        const sprint = await sprintsService.getOne({ objectId: id });
-        console.log(sprint);
+        const sprint = await sprintsService.getOne({ objectId: id }).catch(showError);
         setSprint(sprint);
     };
 
@@ -42,11 +42,11 @@ const AddPost = ({ user, sprintId, push, notificationsProps }) => {
                         sprintId: id,
                         model: 'Sprint',
                     };
-                    return postsService.add(extendedData);
+                    return postsService.add(extendedData).catch(showError);
                 }}
             />
         </AppLayout>
     );
 };
 
-export default authenticatedPage(withPush(AddPost));
+export default authenticatedPage(withPush(withShowError(AddPost)));

--- a/client/src/pages/AddProject.js
+++ b/client/src/pages/AddProject.js
@@ -8,22 +8,28 @@ import { withPush } from '../utils/routingDecorators';
 // import { FORMIK_DATE_FORMAT } from '../utils/constants';
 import AppLayout from '../layouts/AppLayout';
 import '../styles/main.css';
+import withShowError from '../components/withShowError';
 
-const AddProject = ({ user, push, notificationsProps }) => (
-    <AppLayout user={user} {...notificationsProps}>
-        <ProjectForm
-            title="Add new project"
-            initialValues={{
-                title: '',
-                body: '',
-            }}
-            onSubmit={data => {
-                projectsService.add(data).then(() => {
-                    push('/sprints');
-                });
-            }}
-        />
-    </AppLayout>
-);
+const AddProject = ({ user, push, notificationsProps, showError }) => {
+    return (
+        <AppLayout user={user} {...notificationsProps}>
+            <ProjectForm
+                title="Add new project"
+                initialValues={{
+                    title: '',
+                    body: '',
+                }}
+                onSubmit={data => {
+                    projectsService
+                        .add(data)
+                        .then(() => {
+                            push('/sprints');
+                        })
+                        .catch(showError);
+                }}
+            />
+        </AppLayout>
+    );
+};
 
-export default authenticatedPage(withPush(AddProject));
+export default authenticatedPage(withPush(withShowError(AddProject)));

--- a/client/src/pages/AddSprint.js
+++ b/client/src/pages/AddSprint.js
@@ -7,8 +7,9 @@ import { withPush } from '../utils/routingDecorators';
 import { FORMIK_DATE_FORMAT } from '../utils/constants';
 import AppLayout from '../layouts/AppLayout';
 import '../styles/main.css';
+import withShowError from '../components/withShowError';
 
-const AddSprint = ({ user, push, notificationsProps }) => (
+const AddSprint = ({ user, push, notificationsProps, showError }) => (
     <AppLayout user={user} {...notificationsProps}>
         <SprintForm
             title="Add new sprint"
@@ -20,12 +21,15 @@ const AddSprint = ({ user, push, notificationsProps }) => (
                 body: '',
             }}
             onSubmit={data => {
-                sprintsService.add(data).then(() => {
-                    push('/sprints');
-                });
+                sprintsService
+                    .add(data)
+                    .then(() => {
+                        push('/sprints');
+                    })
+                    .catch(showError);
             }}
         />
     </AppLayout>
 );
 
-export default authenticatedPage(withPush(AddSprint));
+export default authenticatedPage(withPush(withShowError(AddSprint)));

--- a/client/src/pages/EditProject.js
+++ b/client/src/pages/EditProject.js
@@ -9,8 +9,9 @@ import { withPush } from '../utils/routingDecorators';
 import AppLayout from '../layouts/AppLayout';
 import Loading from '../components/Loading';
 import '../styles/main.css';
+import withShowError from '../components/withShowError';
 
-const EditProject = ({ user, push, notificationProps }) => {
+const EditProject = ({ user, push, notificationProps, showError }) => {
     const { id } = useParams();
 
     const [project, setProject] = useState(null);
@@ -39,9 +40,12 @@ const EditProject = ({ user, push, notificationProps }) => {
                         body: project.body,
                     }}
                     onSubmit={data => {
-                        projectsService.update({ ...data, objectId: id }).then(() => {
-                            push('/projects');
-                        });
+                        projectsService
+                            .update({ ...data, objectId: id })
+                            .then(() => {
+                                push('/projects');
+                            })
+                            .catch(showError);
                     }}
                 />
             )}
@@ -49,4 +53,4 @@ const EditProject = ({ user, push, notificationProps }) => {
     );
 };
 
-export default authenticatedPage(withPush(EditProject));
+export default authenticatedPage(withPush(withShowError(EditProject)));

--- a/client/src/pages/EditSprint.js
+++ b/client/src/pages/EditSprint.js
@@ -9,15 +9,15 @@ import { FORMIK_DATE_FORMAT } from '../utils/constants';
 import AppLayout from '../layouts/AppLayout';
 import Loading from '../components/Loading';
 import '../styles/main.css';
+import withShowError from '../components/withShowError';
 
-const EditSprint = ({ user, push, notificationsProps }) => {
+const EditSprint = ({ user, push, notificationsProps, showError }) => {
     const { id } = useParams();
 
     const [sprint, setSprint] = useState(null);
 
     const getSprint = async () => {
-        const sprint = await sprintsService.getOne({ objectId: id });
-        console.log(sprint);
+        const sprint = await sprintsService.getOne({ objectId: id }).catch(showError);
         setSprint(sprint);
     };
 
@@ -42,9 +42,12 @@ const EditSprint = ({ user, push, notificationsProps }) => {
                         body: sprint.body,
                     }}
                     onSubmit={data => {
-                        sprintsService.update({ ...data, objectId: id }).then(() => {
-                            push('/sprints');
-                        });
+                        sprintsService
+                            .update({ ...data, objectId: id })
+                            .then(() => {
+                                push('/sprints');
+                            })
+                            .catch(showError);
                     }}
                 />
             )}

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -3,9 +3,9 @@ import AppLayout from '../layouts/AppLayout';
 import AuthForm from '../components/forms/Auth';
 import authService from '../services/authService';
 import { interceptPage } from '../components/interceptPage';
-import NotificationObject from '../logic/NotificationObject';
+import withShowError from '../components/withShowError';
 
-const Login = ({ next, onLoginSuccess, user, notificationsProps }) => {
+const Login = ({ next, onLoginSuccess, user, notificationsProps, showError }) => {
     const { addNotification } = notificationsProps;
     return (
         <AppLayout user={user} {...notificationsProps}>
@@ -23,7 +23,7 @@ const Login = ({ next, onLoginSuccess, user, notificationsProps }) => {
                                 onLoginSuccess(user);
                                 next();
                             })
-                            .catch(err => addNotification(NotificationObject.make(err.toString())));
+                            .catch(showError);
                     }}
                 />
             </div>
@@ -31,4 +31,4 @@ const Login = ({ next, onLoginSuccess, user, notificationsProps }) => {
     );
 };
 
-export default interceptPage(Login);
+export default interceptPage(withShowError(Login));

--- a/client/src/pages/Logout.js
+++ b/client/src/pages/Logout.js
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 import AppLayout from '../layouts/AppLayout';
 import authService from '../services/authService';
-import NotificationObject from '../logic/NotificationObject';
+import withShowError from '../components/withShowError';
 
-const Logout = ({ user, onSuccess, notificationsProps }) => {
+const Logout = ({ user, onSuccess, notificationsProps, showError }) => {
     const { addNotification } = notificationsProps;
 
     const [logoutRequestDone, setLogoutRequestDone] = useState(false);
@@ -14,7 +14,7 @@ const Logout = ({ user, onSuccess, notificationsProps }) => {
             authService
                 .logout()
                 .then(() => onSuccess())
-                .catch(err => addNotification(NotificationObject.make(err.toString())))
+                .catch(showError)
                 .finally(() => setLogoutRequestDone(true));
         }
     });
@@ -30,4 +30,4 @@ const Logout = ({ user, onSuccess, notificationsProps }) => {
     }
 };
 
-export default Logout;
+export default withShowError(Logout);

--- a/client/src/pages/Register.js
+++ b/client/src/pages/Register.js
@@ -3,9 +3,9 @@ import AppLayout from '../layouts/AppLayout';
 import AuthForm from '../components/forms/Auth';
 import authService from '../services/authService';
 import { interceptPage } from '../components/interceptPage';
-import NotificationObject from '../logic/NotificationObject';
+import withShowError from '../components/withShowError';
 
-const Register = ({ user, onSuccess, next, notificationsProps }) => (
+const Register = ({ user, onSuccess, next, notificationsProps, showError }) => (
     <AppLayout user={user} {...notificationsProps}>
         <div className="center">
             <AuthForm
@@ -24,14 +24,11 @@ const Register = ({ user, onSuccess, next, notificationsProps }) => (
                             onSuccess(user);
                             next();
                         })
-                        .catch(err => {
-                            // TODO: structure errors returned from services, render form errors on respective fields
-                            return notificationsProps.addNotification(NotificationObject.make(err.toString()));
-                        });
+                        .catch(showError);
                 }}
             />
         </div>
     </AppLayout>
 );
 
-export default interceptPage(Register);
+export default interceptPage(withShowError(Register));

--- a/client/src/pages/Sprint.js
+++ b/client/src/pages/Sprint.js
@@ -7,16 +7,17 @@ import Loading from '../components/Loading';
 import { SingleSprint } from '../components/sprint/details/SingleSprint';
 import { useParams } from 'react-router-dom';
 import '../styles/main.css';
+import withShowError from '../components/withShowError';
 
-export const Sprint = props => {
-    const { user, notificationsProps } = props;
+const Sprint = props => {
+    const { user, notificationsProps, showError } = props;
 
     const { id } = useParams();
 
     const [sprint, setSprint] = useState(null);
 
     const getSprint = async () => {
-        const sprint = await sprintsService.getOne({ objectId: id });
+        const sprint = await sprintsService.getOne({ objectId: id }).catch(showError);
         setSprint(sprint);
     };
 
@@ -34,3 +35,5 @@ export const Sprint = props => {
         </AppLayout>
     );
 };
+
+export default withShowError(Sprint);

--- a/client/src/pages/Sprints.js
+++ b/client/src/pages/Sprints.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import AppLayout from '../layouts/AppLayout';
 import SprintsView from '../components/sprint/SprintsView';
 
+// TODO: convert to a pure functional component (drop the class keyword).
 class Sprints extends Component {
     constructor(props) {
         super(props);

--- a/client/src/services/__mocks__/sprintsService.js
+++ b/client/src/services/__mocks__/sprintsService.js
@@ -1,0 +1,12 @@
+export let resolveGetAll, rejectGetAll;
+
+// TODO - extract to a reusable testing/ module
+// TODO - consider using the real implementation and mocking axios instead
+const getAllPromiseHandle = new Promise((resolve, reject) => {
+    resolveGetAll = resolve;
+    rejectGetAll = reject;
+});
+
+export default {
+    getAll: () => getAllPromiseHandle,
+};

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+import 'jest-extended';

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4304,7 +4304,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expect@^24.9.0:
+expect@^24.1.0, expect@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
   integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
@@ -6034,6 +6034,20 @@ jest-environment-node@^24.9.0:
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
 
+jest-extended@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-0.11.5.tgz#f063b3f1eaadad8d7c13a01f0dfe0f538d498ccf"
+  integrity sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==
+  dependencies:
+    expect "^24.1.0"
+    jest-get-type "^22.4.3"
+    jest-matcher-utils "^22.0.0"
+
+jest-get-type@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -6087,6 +6101,15 @@ jest-leak-detector@^24.9.0:
   dependencies:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^22.0.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+  integrity sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
 jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
   version "24.9.0"
@@ -8684,6 +8707,14 @@ pretty-error@^2.1.1:
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
+
+pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  integrity sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 pretty-format@^24.0.0, pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
Dodatkowy test dla frontendu + dodanie, po stronie klienta, obsługi błędów zwracanych z serwera.
Coś mogłem przeoczyć, ale teraz jeśli serwer zwróci jakiś kod błędu, to w kliencie powinno pojawić się proste powiadomienie.